### PR TITLE
[ch30323] Adjust json hcl output

### DIFF
--- a/hcl/printer/nodes.go
+++ b/hcl/printer/nodes.go
@@ -228,6 +228,12 @@ func (p *printer) literalType(lit *ast.LiteralType) []byte {
 		// Poison lines 2+ so that we don't indent them
 		result = p.heredocIndent(result)
 	case token.STRING:
+		// If the string token is using interpolation remove the interpolation
+		// leaving the bare variable
+		if bytes.HasPrefix(result, []byte("\"${")) {
+			result = result[3 : len(result)-2]
+		}
+
 		// If this is a multiline string, poison lines 2+ so we don't
 		// indent them.
 		if bytes.IndexRune(result, '\n') >= 0 {


### PR DESCRIPTION
…g tokens that include interpolation

Some example output

```
resource aws_security_group_rule webcropAlertthopter8099egress {
  from_port = "8099"

  lifecycle = {
    create_before_destroy = true
  }

  protocol = "tcp"

  security_group_id = aws_security_group.webcrop_alert.id

  source_security_group_id = aws_security_group.thopter.id

  to_port = "8099"

  type = "egress"
}
```

After this is merged we will have to reinstall `json2hcl`